### PR TITLE
Run prisma generate during Netlify builds

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,8 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
-    "test": "echo \"No tests specified\""
+    "test": "echo \"No tests specified\"",
+    "postinstall": "prisma generate"
   },
   "prisma": {
     "seed": "tsx --require dotenv/config scripts/seed.ts"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[build]
+  base = "app"
+  command = "npx prisma generate && yarn build"
+


### PR DESCRIPTION
## Summary
- ensure Prisma client is generated after dependencies are installed
- have Netlify run `prisma generate` before building the app

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4a9557f68833393a19aa848e56479