### PR TITLE
fix: update prisma client output path

### DIFF
--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -1,7 +1,7 @@
 generator client {
     provider = "prisma-client-js"
     binaryTargets = ["native", "linux-musl-arm64-openssl-3.0.x"]
-    output = "/home/ubuntu/modern_calendar_app/app/node_modules/.prisma/client"
+    output = "/home/ubuntu/chronos/app/node_modules/.prisma/client"
 }
 
 datasource db {


### PR DESCRIPTION
## Summary
- point Prisma client output to /home/ubuntu/chronos/app/node_modules/.prisma/client

## Testing
- `npm install`
- `npx prisma generate`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4aadc8244833399e28c13274101ee